### PR TITLE
Change citation and link colors from bright-green to CVPR blue

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -17,17 +17,16 @@
 %
 % If you comment hyperref and then uncomment it, you should delete *.aux before re-running LaTeX.
 % (Or just hit 'q' on the first LaTeX run, let it finish, and you should be clear).
-\usepackage[pagebackref,breaklinks,colorlinks]{hyperref}
+\usepackage[
+    pagebackref,
+    breaklinks,
+    colorlinks,
+    linkcolor=Maroon,
+    citecolor=NavyBlue!80!black,
+    urlcolor=Plum,
+    filecolor=Aquamarine!80!black
+]{hyperref}
 
-% Change citation and link colors from bright-green to CVPR blue (#357ebd).
-\definecolor{cvprblue}{rgb}{0.21,0.49,0.74}
-\hypersetup{
-    colorlinks=true,
-    linkcolor=cvprblue,
-    citecolor=cvprblue,
-    filecolor=cvprblue,
-    urlcolor=cvprblue
-}
 
 %%%%%%%%% PAPER ID  - PLEASE UPDATE
 \def\paperID{*****} % *** Enter the CVPR Paper ID here

--- a/main.tex
+++ b/main.tex
@@ -17,14 +17,12 @@
 %
 % If you comment hyperref and then uncomment it, you should delete *.aux before re-running LaTeX.
 % (Or just hit 'q' on the first LaTeX run, let it finish, and you should be clear).
+\definecolor{cvprblue}{rgb}{0.21,0.49,0.74}
 \usepackage[
     pagebackref,
     breaklinks,
     colorlinks,
-    linkcolor=Maroon,
-    citecolor=NavyBlue!80!black,
-    urlcolor=Plum,
-    filecolor=Aquamarine!80!black
+    citecolor=cvprblue,
 ]{hyperref}
 
 

--- a/main.tex
+++ b/main.tex
@@ -19,6 +19,16 @@
 % (Or just hit 'q' on the first LaTeX run, let it finish, and you should be clear).
 \usepackage[pagebackref,breaklinks,colorlinks]{hyperref}
 
+% Change citation and link colors from bright-green to CVPR blue (#357ebd).
+\definecolor{cvprblue}{rgb}{0.21,0.49,0.74}
+\hypersetup{
+    colorlinks=true,
+    linkcolor=cvprblue,
+    citecolor=cvprblue,
+    filecolor=cvprblue,
+    urlcolor=cvprblue
+}
+
 %%%%%%%%% PAPER ID  - PLEASE UPDATE
 \def\paperID{*****} % *** Enter the CVPR Paper ID here
 \def\confName{CVPR}


### PR DESCRIPTION
The default link and citation color is a difficult to read bright green. This changes that color to the moderate blue used on the CVPR website (#357ebd).

Before / After:
![Screenshot 2023-06-13 at 12 47 40](https://github.com/cvpr-org/author-kit/assets/1160920/13335f80-125f-4ce7-aced-f64665c25d8a)
