### PR TITLE
Remove cite package given that natbib is used

### DIFF
--- a/cvpr.sty
+++ b/cvpr.sty
@@ -28,7 +28,6 @@
 \ProvidesPackage{cvpr}[2024 Example LaTex class for IEEE CVPR]
 
 \RequirePackage{times}    % Integrate Times for here
-\RequirePackage{cite}     % Automatically ordered citations
 \RequirePackage{xspace}
 \RequirePackage{graphicx}
 \RequirePackage{amsmath}
@@ -592,7 +591,7 @@
 
 % ---------------------------------------------------------------
 
-%% redefine the \title command so that a variable name is saved in \thetitle, and provides the \maketitlesupplementary command 
+%% redefine the \title command so that a variable name is saved in \thetitle, and provides the \maketitlesupplementary command
 \let\titleold\title
 \renewcommand{\title}[1]{\titleold{#1}\newcommand{\thetitle}{#1}}
 \def\maketitlesupplementary


### PR DESCRIPTION
Since natbib was used, then cite is not needed anymore and it clashes with natbib.

This merge will remove the clash.