### PR TITLE
Biblatex port

### DIFF
--- a/cvpr.sty
+++ b/cvpr.sty
@@ -40,6 +40,7 @@
 \WarningFilter{hyperref}{Token not allowed in a PDF string}
 \WarningFilter[rebuttal]{latex}{No \author given}
 \RequirePackage{etoolbox}%% <- for \pretocmd, \apptocmd and \patchcmd
+\RequirePackage{xpatch}% for patching biblatex
 
 % Use modern caption package to allow for sub-figures etc.
 % Reproduces the original CVPR/ICCV style as closely as possible.
@@ -64,13 +65,17 @@ giveninits=true, % abbreviate the authors names, i.e., put only the initials
 
 % Remove strings from the pageref
 \DefineBibliographyStrings{english}{%
-  backrefpage =,% originally "cited on page"
-  backrefpages =,% originally "cited on pages"
+  backrefpage ={},% originally "cited on page"
+  backrefpages ={},% originally "cited on pages"
 }
 
-% Remove spurious white space from pageref when using no string
-\patchcmd{\abx@macro@pageref}{\ppspace}{}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
+% Removes the parenthesis from the backref
+%\DeclareFieldFormat{nobackrefparens}{#1}
+%\xpatchbibmacro{pageref}{parens}{nobackrefparens}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
 
+% Remove spurious white space from pageref when using no string
+\xpatchbibmacro{pageref}{\ppspace}{}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
+\xpatchbibmacro{pageref}{\ppspace}{}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
 
 % Sorts by appearance globally and by year within the citation
 % https://tex.stackexchange.com/a/55451/7561
@@ -83,6 +88,12 @@ giveninits=true, % abbreviate the authors names, i.e., put only the initials
 % Change the normal space to a non-breaking one between the names and the reference
 % https://tex.stackexchange.com/a/74932/7561
 \renewcommand\namelabeldelim{\addnbspace}
+
+% Make the fontsize small
+\renewcommand*{\bibfont}{\normalfont\small}
+
+% Remove quotes from titles
+\DeclareFieldFormat*{title}{#1}
 
 
 \newtoggle{cvprfinal}        % Camera-ready version
@@ -427,13 +438,14 @@ giveninits=true, % abbreviate the authors names, i.e., put only the initials
       \PackageWarningNoLine{cvpr}{Package `hyperref' is not loaded, but highly recommended for camera-ready version}
     }
   }{%
-    \@ifpackageloaded{biblatex}{
-      \@ifpackagewith{biblatex}{backref}{}{
-        \PackageWarningNoLine{cvpr}{Package `biblatex' is not loaded with option `backref', which is strongly recommended for review version}
-      }
-    }{%
-      \PackageWarningNoLine{cvpr}{Package `biblatex' is not loaded, but strongly recommended for review version}
-    }
+    %todo biblatex options are not recognized since it is not "loaded" now.  Probably, we need to add some check up code as suggested here https://tex.stackexchange.com/a/287673/7561
+%    \@ifpackageloaded{biblatex}{
+%      \@ifpackagewith{biblatex}{backref}{}{
+%        \PackageWarningNoLine{cvpr}{Package `biblatex' is not loaded with option `backref', which is strongly recommended for review version}
+%      }
+%    }{%
+%      \PackageWarningNoLine{cvpr}{Package `biblatex' is not loaded, but strongly recommended for review version}
+%    }
   }
 }
 

--- a/cvpr.sty
+++ b/cvpr.sty
@@ -69,6 +69,8 @@ giveninits=true, % abbreviate the authors names, i.e., put only the initials
   backrefpages ={},% originally "cited on pages"
 }
 
+%% Adapting the default style to CVPR's quirks
+
 % Removes the parenthesis from the backref
 %\DeclareFieldFormat{nobackrefparens}{#1}
 %\xpatchbibmacro{pageref}{parens}{nobackrefparens}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
@@ -76,6 +78,28 @@ giveninits=true, % abbreviate the authors names, i.e., put only the initials
 % Remove spurious white space from pageref when using no string
 \xpatchbibmacro{pageref}{\ppspace}{}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
 \xpatchbibmacro{pageref}{\ppspace}{}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
+
+% Revert unit divider to period
+\renewcommand*\newunitpunct{\addperiod\addspace}
+
+% Change format of volume-number-editor
+\DeclareFieldFormat*{volume}{#1}
+
+\renewbibmacro*{volume+number+eid}{%
+  \printfield{volume}%
+  \printfield[parens]{number}%
+  \setunit{\addcolon\addspace}%
+  \printfield{eid}%
+}
+
+% Change pages separator to colon on article
+\renewcommand{\bibpagespunct}{\ifentrytype{article}{\addcolon\addspace}{\addcomma\addspace}}
+\DeclareFieldFormat[article,incollection]{pages}{#1}
+
+% Remove quotes from titles
+\DeclareFieldFormat*{title}{#1}
+
+
 
 % Sorts by appearance globally and by year within the citation
 % https://tex.stackexchange.com/a/55451/7561
@@ -92,8 +116,6 @@ giveninits=true, % abbreviate the authors names, i.e., put only the initials
 % Make the fontsize small
 \renewcommand*{\bibfont}{\normalfont\small}
 
-% Remove quotes from titles
-\DeclareFieldFormat*{title}{#1}
 
 
 \newtoggle{cvprfinal}        % Camera-ready version

--- a/cvpr.sty
+++ b/cvpr.sty
@@ -18,24 +18,20 @@
 %  * "rebuttal" for the author rebuttal.
 %
 % specify references as
-%   {\small
-%   \bibliographystyle{ieee}
-%   \bibliography{...your files...}
-%   }
+%   \addbibresource{references.bib}
+% in the preamble
 % ---------------------------------------------------------------
 
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesPackage{cvpr}[2024 Example LaTex class for IEEE CVPR]
 
 \RequirePackage{times}    % Integrate Times for here
-\RequirePackage{cite}     % Automatically ordered citations
 \RequirePackage{xspace}
 \RequirePackage{graphicx}
 \RequirePackage{amsmath}
 \RequirePackage{amssymb}
 \RequirePackage{booktabs}
-\RequirePackage[numbers,sort&compress]{natbib}
-\setlength{\bibsep}{1pt plus 1pt minus 1pt}
+%\setlength{\bibsep}{1pt plus 1pt minus 1pt}
 
 \RequirePackage{silence}  % Suppress unwanted warnings
 \hbadness=10000 \vbadness=10000 \vfuzz=30pt \hfuzz=30pt
@@ -43,12 +39,50 @@
 \WarningFilter{latex}{Font shape}
 \WarningFilter{hyperref}{Token not allowed in a PDF string}
 \WarningFilter[rebuttal]{latex}{No \author given}
-\RequirePackage{etoolbox}
+\RequirePackage{etoolbox}%% <- for \pretocmd, \apptocmd and \patchcmd
 
 % Use modern caption package to allow for sub-figures etc.
 % Reproduces the original CVPR/ICCV style as closely as possible.
 \RequirePackage[format=plain,labelformat=simple,labelsep=period,font=small,compatibility=false]{caption}
 \RequirePackage[font=footnotesize,skip=3pt,subrefformat=parens]{subcaption}
+
+%% References
+
+% Breaking lines for URLs in the bib
+\RequirePackage[hyphens]{url}
+%todo check if this below is needed
+\Urlmuskip=0mu plus 1mu\relax
+
+\RequirePackage[
+backend=biber,
+style=ieee,
+sorting=noneyear,
+backref=true,
+natbib=true, % add citep and citet
+giveninits=true, % abbreviate the authors names, i.e., put only the initials
+]{biblatex}
+
+% Remove strings from the pageref
+\DefineBibliographyStrings{english}{%
+  backrefpage =,% originally "cited on page"
+  backrefpages =,% originally "cited on pages"
+}
+
+% Remove spurious white space from pageref when using no string
+\patchcmd{\abx@macro@pageref}{\ppspace}{}{}{\PackageWarningNoLine{cvpr}{Error patching pageref bibmacro.  Let the maintainers know that the patch is not working.}}
+
+
+% Sorts by appearance globally and by year within the citation
+% https://tex.stackexchange.com/a/55451/7561
+\DeclareSortingTemplate{noneyear}{
+  \sort{\citeorder}
+  \sort{\field{year}}
+  \sort{\field{author}}
+}
+
+% Change the normal space to a non-breaking one between the names and the reference
+% https://tex.stackexchange.com/a/74932/7561
+\renewcommand\namelabeldelim{\addnbspace}
 
 
 \newtoggle{cvprfinal}        % Camera-ready version
@@ -68,9 +102,7 @@
   \ActivateWarningFilters[rebuttal]
 }{}
 
-% Breaking lines for URLs in the bib
-\RequirePackage[hyphens]{url}
-\Urlmuskip=0mu plus 1mu\relax
+
 
 
 % ---------------------------------------------------------------
@@ -395,12 +427,12 @@
       \PackageWarningNoLine{cvpr}{Package `hyperref' is not loaded, but highly recommended for camera-ready version}
     }
   }{%
-    \@ifpackageloaded{hyperref}{
-      \@ifpackagewith{hyperref}{pagebackref}{}{
-        \PackageWarningNoLine{cvpr}{Package `hyperref' is not loaded with option `pagebackref', which is strongly recommended for review version}
+    \@ifpackageloaded{biblatex}{
+      \@ifpackagewith{biblatex}{backref}{}{
+        \PackageWarningNoLine{cvpr}{Package `biblatex' is not loaded with option `backref', which is strongly recommended for review version}
       }
     }{%
-      \PackageWarningNoLine{cvpr}{Package `hyperref' is not loaded, but strongly recommended for review version}
+      \PackageWarningNoLine{cvpr}{Package `biblatex' is not loaded, but strongly recommended for review version}
     }
   }
 }
@@ -505,8 +537,6 @@
 % Patch amsmath commands so that the previous line and the equation itself
 % are numbered. Bug: multiline has an extra line number.
 % https://tex.stackexchange.com/questions/461186/how-to-use-lineno-with-amsmath-align
-\RequirePackage{etoolbox} %% <- for \pretocmd, \apptocmd and \patchcmd
-
 \newcommand*\linenomathpatch[1]{%
   \expandafter\pretocmd\csname #1\endcsname {\linenomath}{}{}%
   \expandafter\pretocmd\csname #1*\endcsname {\linenomath}{}{}%
@@ -592,7 +622,7 @@
 
 % ---------------------------------------------------------------
 
-%% redefine the \title command so that a variable name is saved in \thetitle, and provides the \maketitlesupplementary command 
+%% redefine the \title command so that a variable name is saved in \thetitle, and provides the \maketitlesupplementary command
 \let\titleold\title
 \renewcommand{\title}[1]{\titleold{#1}\newcommand{\thetitle}{#1}}
 \def\maketitlesupplementary

--- a/main.tex
+++ b/main.tex
@@ -1,3 +1,4 @@
+% !BIB program=biber
 % CVPR 2024 Paper Template; see https://github.com/cvpr-org/author-kit
 
 \documentclass[10pt,twocolumn,letterpaper]{article}
@@ -12,12 +13,15 @@
 
 % It is strongly recommended to use hyperref, especially for the review version.
 % hyperref with option pagebackref eases the reviewers' job.
-% Please disable hyperref *only* if you encounter grave issues, 
+% Please disable hyperref *only* if you encounter grave issues,
 % e.g. with the file validation for the camera-ready version.
 %
 % If you comment hyperref and then uncomment it, you should delete *.aux before re-running LaTeX.
 % (Or just hit 'q' on the first LaTeX run, let it finish, and you should be clear).
-\usepackage[pagebackref,breaklinks,colorlinks]{hyperref}
+\usepackage[breaklinks,colorlinks]{hyperref}
+
+% Add your own bibliography
+\addbibresource{main.bib}
 
 %%%%%%%%% PAPER ID  - PLEASE UPDATE
 \def\paperID{*****} % *** Enter the Paper ID here
@@ -46,15 +50,13 @@ First line of institution2 address\\
 
 \begin{document}
 \maketitle
-\input{sec/0_abstract}    
+\input{sec/0_abstract}
 \input{sec/1_intro}
 \input{sec/2_formatting}
 \input{sec/3_finalcopy}
-{
-    \small
-    \bibliographystyle{ieeenat_fullname}
-    \bibliography{main}
-}
+
+\printbibliography
+
 \input{sec/X_suppl}
 
 \end{document}


### PR DESCRIPTION
This is an attempt to port the template to use biblatex (and biber) as default reference setup.  This will solve the comments on #7. 

The setup uses the default IEEE bibliography style which should be compatible with CVPR (as far as I know).  Check if there are inconsistencies or other changes that may be needed, and report them back.

I left the parenthesis on the backref page list used in the standard style since it makes it cleaner than a list of numbers after the reference.

The first names are abbreviated to save space, but that can be removed if needed.