### PR TITLE
Remove indentation of first abstract paragraph

### DIFF
--- a/cvpr.sty
+++ b/cvpr.sty
@@ -441,8 +441,8 @@
      \thispagestyle{empty}
    }
    \centerline{\large\bf Abstract}%
-   \vspace*{12pt}%
-   \it%
+   \vspace*{12pt}\noindent%
+   \it\ignorespaces%
 }
 
 \def\endabstract{%


### PR DESCRIPTION
This is similar to other first paragraphs after a heading.

## Before
<img width="423" alt="Screenshot 2023-10-19 at 20 40 54" src="https://github.com/cvpr-org/author-kit/assets/8134692/d19378a6-a63a-4192-a072-ca8ee0fbc7f2">

## After
<img width="424" alt="Screenshot 2023-10-19 at 20 41 53" src="https://github.com/cvpr-org/author-kit/assets/8134692/029233ed-56ef-494e-a731-d705a922dfa3">
