### PR TITLE
Fix the starting number for natbib in the rebuttal

### DIFF
--- a/rebuttal.tex
+++ b/rebuttal.tex
@@ -24,15 +24,11 @@
 %\setcounter{equation}{2}
 
 % If you wish to avoid re-using reference numbers from the main paper,
-% please uncomment the following and change the counter for `enumiv' to
-% the number of references you have in the main paper (here, 6).
-%\let\oldthebibliography=\thebibliography
-%\let\oldendthebibliography=\endthebibliography
-%\renewenvironment{thebibliography}[1]{%
-%     \oldthebibliography{#1}%
-%     \setcounter{enumiv}{6}%
-%}{\oldendthebibliography}
-
+% please uncomment the following and change the counter value to the
+% number of references you have in the main paper (here, 100).
+%\makeatletter
+%\apptocmd{\thebibliography}{\global\c@NAT@ctr 100\relax}{}{}
+%\makeatother
 
 %%%%%%%%% PAPER ID  - PLEASE UPDATE
 \def\paperID{*****} % *** Enter the Paper ID here


### PR DESCRIPTION
This PR fixes renumbering the references in the rebuttal, as it used to work before the switch to natbib. As before, this is commented out by default, so the numbering starts at 1:
<img width="351" alt="image" src="https://github.com/cvpr-org/author-kit/assets/8134692/129d30de-a70f-4a29-b0ff-25b689950479">

After commenting out the following lines in `rebuttal.tex`:
```latex
\makeatletter
\apptocmd{\thebibliography}{\global\c@NAT@ctr 100\relax}{}{}
\makeatother
```
the references start at 101 (continuing the sequence of 100 assumed citations in the main paper:
<img width="348" alt="image" src="https://github.com/cvpr-org/author-kit/assets/8134692/b91f4bfe-1be1-4558-a834-fdbe41fd7e9f">

