### PR TITLE
Set hyperref to use cvprblue color for all hyperlinks.

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -18,7 +18,7 @@
 % If you comment hyperref and then uncomment it, you should delete *.aux before re-running LaTeX.
 % (Or just hit 'q' on the first LaTeX run, let it finish, and you should be clear).
 \definecolor{cvprblue}{rgb}{0.21,0.49,0.74}
-\usepackage[pagebackref,breaklinks,colorlinks,citecolor=cvprblue]{hyperref}
+\usepackage[pagebackref,breaklinks,colorlinks,allcolors=cvprblue]{hyperref}
 
 %%%%%%%%% PAPER ID  - PLEASE UPDATE
 \def\paperID{*****} % *** Enter the Paper ID here

--- a/rebuttal.tex
+++ b/rebuttal.tex
@@ -14,7 +14,7 @@
 % egpaper.aux before re-running latex.  (Or just hit 'q' on the first latex
 % run, let it finish, and you should be clear).
 \definecolor{cvprblue}{rgb}{0.21,0.49,0.74}
-\usepackage[pagebackref,breaklinks,colorlinks,citecolor=cvprblue]{hyperref}
+\usepackage[pagebackref,breaklinks,colorlinks,allcolors=cvprblue]{hyperref}
 
 % If you wish to avoid re-using figure, table, and equation numbers from
 % the main paper, please uncomment the following and change the numbers


### PR DESCRIPTION
This pull request changes the `hyperref` arguments so that it uses the `cvprblue` color for all hyperlinks (external URLs, citations, references to figures, tables, sections, and so on). 

Previously, `hyperref` would use `cvprblue` only for citations, and would use default colors for other types of hyperlinks.