### PR TITLE
Include inline and shortlabels options to enumitem.

### DIFF
--- a/cvpr.sty
+++ b/cvpr.sty
@@ -622,6 +622,6 @@
 % ---------------------------------------------------------------
 
 %% More compact compact itemize/enumeration (e.g. list contributions)
-\RequirePackage{enumitem}
+\RequirePackage[shortlabels,inline]{enumitem}
 \setlist[itemize]{noitemsep,leftmargin=*,topsep=0em}
 \setlist[enumerate]{noitemsep,leftmargin=*,topsep=0em}


### PR DESCRIPTION
Add options `inline` and `shortlabels` to package `enumitem` loaded by `cvpr.sty`.

The `inline` option makes it possible to use the `enumerate*` environment to create inline lists. For example, instead of typing the sentence:

		We observe that our model: 1. works much better than the state of the art; and 2. is much faster than 
		the previous best implementation.

you can type

		We observe that our model:
		%
		\begin{enumerate*}
				\item works much better than the state of the art; and 
				\item is much faster than the previous best implementation.
		\end{enumerate*}

The end result is the same, but using `enumerate*` has a few advantages:
- It ensures all inline lists throughout the paper have consistent formatting (i.e., all use Arabic or Latin numerals, all use parentheses or dots).
- It makes it easy to make global changes to the formatting of inline lists.
- It automatically creates correct numbering (e.g., if you later add or remove a list item).
- It makes it easy to switch between inline versus non-inline lists (e.g., during shortening, if you decide to make everything inline to save space), by simply inserting or removing `*`.

The `shortlabels` option provides some simple syntax for changing `enumerate` labels in both inline and non-inline lists.