### PR TITLE
add subsubsection styles & fix wrong PDF bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ### History (in reverse chronological order)
 
+- added styles for `subsubsection` and fixed the wrong PDF bookmarks by [Di Fang](https://github.com/fang-d)
 - modernized for CVPR 2025 by [Christian Richardt](https://richardt.name/)
 - fixed page centering for CVPR 2025 by [Stefan Roth](mailto:stefan.roth@NOSPAMtu-darmstadt.de)
 - inline enumerations and `cvprblue` links for CVPR 2025 by [Ioannis Gkioulekas

--- a/cvpr.sty
+++ b/cvpr.sty
@@ -41,7 +41,6 @@
 \hbadness=10000 \vbadness=10000 \vfuzz=30pt \hfuzz=30pt
 \WarningFilter{latexfont}{Font shape declaration}
 \WarningFilter{latex}{Font shape}
-\WarningFilter{hyperref}{Token not allowed in a PDF string}
 \WarningFilter[rebuttal]{latex}{No \author given}
 \RequirePackage{etoolbox}
 
@@ -221,11 +220,13 @@
 % change the name here:
 \font\cvprtenhv  = phvb at 8pt % *** IF THIS FAILS, SEE cvpr.sty ***
 \font\elvbf  = ptmb scaled 1100
+\font\tenbf  = ptmb scaled 1000
 
 % If the above lines give an error message, try to comment them and
 % uncomment these:
 %\font\cvprtenhv  = phvb7t at 8pt
 %\font\elvbf  = ptmb7t scaled 1100
+%\font\tenbf  = ptmb7t scaled 1000
 
 % set dimensions of columns, gap between columns, and paragraph indent
 \setlength{\textheight}{8.875in}
@@ -327,14 +328,20 @@
 \def\cvprsection{\@startsection {section}{1}{\z@}
    {-10pt plus -2pt minus -2pt}{7pt} {\large\bf}}
 \def\cvprssect#1{\cvprsection*{#1}}
-\def\cvprsect#1{\cvprsection{\hskip -1em.~#1}}
+\def\cvprsect#1{\cvprsection{\texorpdfstring{\hskip -1em.~}{}#1}}
 \def\section{\@ifstar\cvprssect\cvprsect}
 
 \def\cvprsubsection{\@startsection {subsection}{2}{\z@}
-   {-8pt plus -2pt minus -2pt}{6pt} {\elvbf}}
+   {-8pt plus -2pt minus -2pt}{5pt} {\elvbf}}
 \def\cvprssubsect#1{\cvprsubsection*{#1}}
-\def\cvprsubsect#1{\cvprsubsection{\hskip -1em.~#1}}
+\def\cvprsubsect#1{\cvprsubsection{\texorpdfstring{\hskip -1em.~}{}#1}}
 \def\subsection{\@ifstar\cvprssubsect\cvprsubsect}
+
+\def\cvprsubsubsection{\@startsection {subsubsection}{3}{\z@}
+   {-6pt plus -2pt minus -2pt}{3pt} {\tenbf}}
+\def\cvprssubsubsect#1{\cvprsubsubsection*{#1}}
+\def\cvprsubsubsect#1{\cvprsubsubsection{\texorpdfstring{\hskip -1em.~}{}#1}}
+\def\subsubsection{\@ifstar\cvprssubsubsect\cvprsubsubsect}
 
 %% --------- Page background marks: Ruler and confidentiality (only for review and rebuttal)
 \iftoggle{cvprfinal}{}{


### PR DESCRIPTION
1. Add correct heading spacing and type for the `subsubsection` in LaTeX.
2. Fix the wrong PDF bookmarks by removing the prefix dot.
3. Fix the hyperref warning "Token not allowed in a PDF string (Unicode)".

![BeforeAfter1](https://github.com/user-attachments/assets/5ca8bc39-ec8f-4be9-8daa-5945486bc8f9)
![BeforeAfter2](https://github.com/user-attachments/assets/503bdc9e-0d2e-44ef-ac80-ff071fc3d332)
![BeforeAfter3](https://github.com/user-attachments/assets/3c461ecc-4a7b-4135-8a50-1bba750f0510)

CC: @taiya, @cr333.

Thanks for considering my pull request.

