### PR TITLE
fix: Italicize the "et al." generated by the `\citet` command

### DIFF
--- a/ieeenat_fullname.bst
+++ b/ieeenat_fullname.bst
@@ -229,7 +229,7 @@ FUNCTION {format.names}
                 'skip$
               if$
               t "others" =
-                { " et~al." * }
+                { " \etal" * }
                 { " and " * t * }
               if$
             }
@@ -326,7 +326,7 @@ FUNCTION {format.full.names}
                 'skip$
               if$
               t "others" =
-                { " et~al." * }
+                { " \etal" * }
                 { " and " * t * }
               if$
             }
@@ -1115,11 +1115,11 @@ FUNCTION {format.lab.names}
   s #1 "{vv~}{ll}" format.name$
   s num.names$ duplicate$
   #2 >
-    { pop$ " et~al." * }
+    { pop$ " \etal" * }
     { #2 <
         'skip$
         { s #2 "{ff }{vv }{ll}{ jj}" format.name$ "others" =
-            { " et~al." * }
+            { " \etal" * }
             { " and " * s #2 "{vv~}{ll}" format.name$ * }
           if$
         }


### PR DESCRIPTION
Italicize the "et al." generated by the `\citet` command by replacing the "et~al." in the bst file with the `\etal` marco defined in `cvpr.sty`.

![BeforeAfter](https://github.com/user-attachments/assets/868296c7-790d-4bf2-b5db-4952779ff657)

Thanks for considering my pull request.

CC: @cr333, @taiya.