### PR TITLE
teaser w/ strip and preamble tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You may find the 2024 version [here](https://github.com/cvpr-org/author-kit/rele
 - added natbib for CVPR 2024 by [Christian Richardt](https://richardt.name/)
 - replaced buggy (review-mode) line numbering for 3DV 2024 by [Adín Ramírez Rivera
 ](https://openreview.net/profile?id=~Ad%C3%ADn_Ram%C3%ADrez_Rivera1)
-- setup github repo of author-kit [Andrea Tagliasacchi](https://theialab.ca)
+- setup github repo of author-kit for 3DV 2025 by [Andrea Tagliasacchi](https://theialab.ca)
 - modernized for CVPR 2022 by [Stefan Roth](mailto:stefan.roth@NOSPAMtu-darmstadt.de)
 - created cvpr.sty file to unify review/rebuttal/final versions by [Ming-Ming Cheng](https://github.com/MCG-NKU/CVPR_Template)
 - developed CVPR 2005 template  by [Paolo Ienne](mailto:Paolo.Ienne@di.epfl.ch) and [Andrew Fitzgibbon](mailto:awf@acm.org)

--- a/fig/teaser.tex
+++ b/fig/teaser.tex
@@ -1,0 +1,8 @@
+\begin{strip}
+\centering
+\includegraphics[width=.325\linewidth]{example-image-golden}
+\includegraphics[width=.325\linewidth]{example-image-golden}
+\includegraphics[width=.325\linewidth]{example-image-golden}
+\captionof{figure}{\textbf{Teaser} -- example of a 2-column teaser. This figure appears at the top of the first page, and a two-column teaser is not mandatory.}
+\label{fig:\currfilebase}
+\end{strip}

--- a/fig/teaser.tex
+++ b/fig/teaser.tex
@@ -1,8 +1,10 @@
 \begin{strip}
 \centering
-\includegraphics[width=.325\linewidth]{example-image-golden}
-\includegraphics[width=.325\linewidth]{example-image-golden}
-\includegraphics[width=.325\linewidth]{example-image-golden}
+\includegraphics[width=.33\linewidth]{example-image-golden}\hfill
+\includegraphics[width=.33\linewidth]{example-image-golden}\hfill
+\includegraphics[width=.33\linewidth]{example-image-golden}
+\captionsetup{hypcap=false}
 \captionof{figure}{\textbf{Teaser} -- example of a 2-column teaser. This figure appears at the top of the first page, and a two-column teaser is not mandatory.}
-\label{fig:\currfilebase}
+\captionsetup{hypcap=true}
+\label{fig:\currfilebase}%
 \end{strip}

--- a/main.tex
+++ b/main.tex
@@ -47,6 +47,7 @@ First line of institution2 address\\
 
 \begin{document}
 \maketitle
+\input{fig/teaser}
 \input{sec/0_abstract}    
 \input{sec/1_intro}
 \input{sec/2_formatting}

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,6 +1,24 @@
 %% This file contains a number of tweaks that are typically applied to the main document.
 %% They are not enabled by default, but can be enabled by uncommenting the relevant lines.
 
+
+%%
+%% Official support for 2-column teaser figure
+%%
+\usepackage{cuted} %< for strip environment
+
+%%
+%% For auto-referencing of figures (see fig/teaser.tex and \label{} therein) 
+%%
+\usepackage{currfile} %< for \currfilebase macro
+
+%%
+%% caption and (global) spacing overrides
+%%
+\usepackage{caption} %< for "\captionof" commands (teaser)
+% \setlength{\abovecaptionskip}{.5em} % space above caption
+% \setlength{\belowcaptionskip}{1em} % space below caption
+
 %%
 %% Inline annotations; for predefined colors, refer to "dvipsnames" in the xcolor package:
 %% https://tinyurl.com/overleaf-colors
@@ -48,3 +66,7 @@
 %%
 % \usepackage{soul}
 % \setuldepth{foobar}
+
+%%
+%% Reconfigure paragraph (tweaks spacing)
+%%

--- a/sec/2_formatting.tex
+++ b/sec/2_formatting.tex
@@ -92,7 +92,7 @@ If you do not wish to abbreviate the label, for example, at the beginning of the
 \end{verbatim}}
 command. Here is an example:
 \begin{quotation}
-  \Cref{fig:onecol} is also quite important.
+  \Cref{fig:onecol} is quite important, but \Cref{fig:teaser} typically even more so, as it's the first figure the reader will see.
 \end{quotation}
 
 %-------------------------------------------------------------------------


### PR DESCRIPTION
Found a much better way to get two-column teasers integrated (credit: Jan Held)
Also, added a few goodies for "auto-naming" of references based on file names.